### PR TITLE
add tdiary-packages plugin

### DIFF
--- a/js/tdiary-packages.js
+++ b/js/tdiary-packages.js
@@ -1,0 +1,48 @@
+/*
+ * tdiary-packages.js: show tdiary package links
+ *
+ * Copyright (c) MATSUOKA Kohei <http://www.machu.jp/>
+ * Distributed under the GPL2 or any later version.
+ */
+
+$(function() {
+  var endpoint = "https://api.github.com/repos/tdiary/tdiary-core";
+
+  $.get(endpoint + "/releases/latest", function(data) {
+    var packages = {
+      'tdiary-full':    { name: "フルセット", order: 1 },
+      'tdiary':         { name: "基本セット", order: 2 },
+      'tdiary-theme':   { name: "テーマ集",   order: 3 },
+      'tdiary-blogkit': { name: "BlogKit",    order: 4 },
+      'tdiary-contrib': { name: "contrib",    order: 5 }
+    };
+
+    var ul = $('<ul>');
+    $(data.assets).map(function(index, asset) {
+      var url = asset.browser_download_url;
+      var name = url.match(/([^/]+)-v\d/)[1];
+      return $('<li>')
+        .data('order', packages[name].order)
+        .append(
+          $('<a>')
+            .attr('href', url)
+            .text(packages[name].name)
+        );
+    }).sort(function(a, b) {
+      return a.data('order') - b.data('order');
+    }).each(function(index, element) {
+      ul.append(element);
+    });
+
+    $('div.tdiary-packages')
+      .append(
+        $('<a>')
+          .attr('href', data.html_url)
+          .text('tDiary ' + data.tag_name)
+      )
+      .append(ul);
+  })
+  .fail(function (){
+    $('div.tdiary-packages').append('<p>パッケージ情報を取得できませんでした</p>');
+  });
+});

--- a/misc/plugin/tdiary-packages.rb
+++ b/misc/plugin/tdiary-packages.rb
@@ -1,3 +1,8 @@
+# tdiary-packages.rb: show tdiary package links
+# 
+# Copyright (c) MATSUOKA Kohei <http://www.machu.jp/>
+# Distributed under the GPL2 or any later version.
+
 enable_js('tdiary-packages.js')
 
 def tdiary_packages

--- a/misc/plugin/tdiary-packages.rb
+++ b/misc/plugin/tdiary-packages.rb
@@ -1,0 +1,5 @@
+enable_js('tdiary-packages.js')
+
+def tdiary_packages
+  %Q(<div class="tdiary-packages"></div>)
+end

--- a/tdiary.conf
+++ b/tdiary.conf
@@ -333,6 +333,7 @@ FOOTER
 #   は、@secureをtrueにして下さい。危険な変数操作や、ファイルの読み込み
 #   が制限されます。
 #----
+@options['sp.path'] = ['misc/plugin']
 @options['sp.selected'] = %w(amazon.rb append-css.rb blog-category.rb blog-style.rb category_to_tag.rb comment_mail-smtp.rb disp_referrer.rb footnote.rb google_analytics.rb hide-mail-field.rb html_anchor.rb image.rb list.rb lm.rb socialbutton.rb squeeze.rb title-link.rb title-navi.rb whatsnew-list.rb ).join("\n")
 @secure = false
 load_cgi_conf


### PR DESCRIPTION
tDiaryパッケージのダウンロード用リンクを自動で取得するプラグイン。GitHub APIを使って実装している。see #3
#9 のようにサーバ側で取得するのではなく、JavaScriptを使って取得するようにした。
